### PR TITLE
feat: alter api and use erlang logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,40 +3,78 @@
 [![Package Version](https://img.shields.io/hexpm/v/comet)](https://hex.pm/packages/comet)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-ffaff3)](https://hexdocs.pm/comet/)
 
+✨Create a gleaming trail of application logs✨
+
+## Status
+In Progress:
+- Logging interface: Proposed
+- Erlang logging operational
+- Javascript logging currently broken
+
+Not Started:
+- Log Filters
+- Log Handlers
+- Improved output formatting
+- JSON output
+- Field customization
+- Documentation
+
+## Usage
+
 ```sh
 gleam add comet
 ```
 ```gleam
-import comet.{Debug, Info, Warn, Error as Err, String, Int}
+import comet.{attribute}
+
+type LogAttribute {
+  Service(String)
+  Latency(Float)
+  StatusCode(Int)
+  Success(Bool)
+  Err(String)
+}
 
 pub fn main() {
-  let log = comet.builder()
-  |> comet.timestamp
-  |> comet.attributes([String("service", "comet")])
-  |> comet.log_level(Info)
-  |> comet.logger
+  // intitialize the underlying logger settings
+  comet.new()
+  |> comet.level(Info)
+  |> comet.configure()
 
-  log(Info, "application starting...", [String("fn", "main"), Int("process", 1)])
+  let log = comet.log()
+    |> attribute(Service("comet"))
+
+  log
+  |> debug("did this work? hi mom")
+
+  log
+  |> attribute(Latency(24.2))
+  |> attribute(StatusCode(200))
+  |> attribute(Success(True))
+  |> info("access log")
+
+  log
+  |> attribute(Latency(102.2))
+  |> attribute(StatusCode(400))
+  |> attribute(Err("input not accepted"))
+  |> attribute(Success(False))
+  |> warning("access log")
+
+  log
+  |> attribute(Latency(402.0))
+  |> attribute(StatusCode(500))
+  |> attribute(Err("database connection error"))
+  |> attribute(Success(False))
+  |> error("access log")
 }
 ```
 
 outputs the log
 ```
-{"level":"info","timestamp":"2024-04-23T06:33:59.101Z","service":"comet","fn":"main","process":1,"msg":"application starting..."}
-```
-
-Additionally, level specific log functions can be created:
-
-```gleam
-  let assert comet.LevelLoggerSet(trace, debug, info, warn, err) =
-    comet.builder()
-    |> comet.timestamp
-    |> comet.attributes([comet.String("service", "comet")])
-    |> comet.log_level(Info)
-    |> comet.logger
-    |> comet.levels
-  debug("log settings", [String("min_log_level", "info")])
-  info("✨ application starting...", [String("fn", "main"), Int("process", 1)])
+level: debug | [Service("comet")] | did this work? hi mom
+level: info | [Success(True), StatusCode(200), Latency(24.2), Service("comet")] | access log
+level: warn | [Success(False), Err("input not accepted"), StatusCode(400), Latency(102.2), Service("comet")] | access log
+level: error | [Success(False), Err("database connection error"), StatusCode(500), Latency(402.0), Service("comet")] | access log
 ```
 
 Further documentation can be found at <https://hexdocs.pm/comet>.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 In Progress:
 - Logging interface: Proposed
 - Erlang logging operational
-- Javascript logging currently broken
+- Javascript logging operational
 
 Not Started:
 - Log Filters

--- a/gleam.toml
+++ b/gleam.toml
@@ -3,13 +3,12 @@ version = "0.1.0"
 description = "Create a gleaming trail of application logs"
 licences = ["MIT"]
 repository = { type = "github", user = "bnprtr", repo = "comet" }
+gleam = ">= 0.32.0"
 
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
-gleam_json = ">= 1.0.0 and < 2.0.0"
-birl = ">= 1.6.1 and < 2.0.0"
 gleam_erlang = ">= 0.25.0 and < 1.0.0"
-gleam_otp = ">= 0.10.0 and < 1.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
+gleam_otp = ">= 0.10.0 and < 1.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -14,7 +14,7 @@ packages = [
 
 [requirements]
 birl = { version = ">= 1.6.1 and < 2.0.0" }
-gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
+gleam_erlang = { version = ">= 0.25.0 and < 1.0.0"}
 gleam_json = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,20 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "birl", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "976CFF85D34D50F7775896615A71745FBE0C325E50399787088F941B539A0497" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
-  { name = "gleam_json", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "8B197DD5D578EA6AC2C0D4BDC634C71A5BCA8E7DB5F47091C263ECB411A60DF3" },
   { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
   { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
   { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
-  { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
-  { name = "thoas", version = "0.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "4918D50026C073C4AB1388437132C77A6F6F7C8AC43C60C13758CC0ADCE2134E" },
 ]
 
 [requirements]
-birl = { version = ">= 1.6.1 and < 2.0.0" }
-gleam_erlang = { version = ">= 0.25.0 and < 1.0.0"}
-gleam_json = { version = ">= 1.0.0 and < 2.0.0" }
+gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
 gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -16,6 +16,6 @@ packages = [
 birl = { version = ">= 1.6.1 and < 2.0.0" }
 gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
 gleam_json = { version = ">= 1.0.0 and < 2.0.0" }
-gleam_otp = { version = ">= 0.10.0 and < 1.0.0"}
+gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/comet.gleam
+++ b/src/comet.gleam
@@ -94,6 +94,10 @@ pub fn attribute(md: Metadata(t), attribute: t) -> Metadata(t) {
   list.prepend(md, attribute)
 }
 
+pub fn attributes(md: Metadata(t), attributes: List(t)) -> Metadata(t) {
+  list.append(md, attributes)
+}
+
 pub type Entry(t) {
   Entry(level: Level, message: String, metadata: Metadata(t))
 }

--- a/src/comet.gleam
+++ b/src/comet.gleam
@@ -11,36 +11,10 @@ import gleam/option.{type Option, None, Some}
 import gleam/result
 import gleam/string
 
-pub opaque type Configuration {
-  Configuration(
-    level_text: fn(Level) -> String,
-    formatter: Formatter,
-    min_level: Level,
-    filters: Filters,
-    metadata: Metadata,
-    outputs: List(Output),
-  )
-}
-
-pub fn new() -> Configuration {
-  Configuration(
-    level_text,
-    text_formatter,
-    Info,
-    dict.new(),
-    new_metadata(),
-    [],
-  )
-}
-
-@external(erlang, "comet_ffi", "configure")
-@external(javascript, "./logs.mjs", "set_config")
-pub fn configure(config: Configuration) -> Nil
-
 pub type Level {
   Debug
   Info
-  Warn
+  Warning
   Err
   Panic
 }
@@ -49,7 +23,7 @@ pub fn level_text(level: Level) -> String {
   case level {
     Debug -> "debug"
     Info -> "info"
-    Warn -> "warn"
+    Warning -> "warn"
     Err -> "error"
     Panic -> "panic"
   }
@@ -59,32 +33,331 @@ pub fn level_priority(level: Level) -> Int {
   case level {
     Debug -> 1
     Info -> 2
-    Warn -> 3
+    Warning -> 3
     Err -> 4
     Panic -> 5
   }
 }
 
+// Context ---------------------------------------------------------------------------
+
+pub opaque type Context {
+  Context(
+    level_text: fn(Level) -> String,
+    formatter: Formatter,
+    filters: Filters,
+    min_level: Level,
+    metadata: Metadata,
+    default_handler: Option(Handler),
+    handlers: List(Handler),
+  )
+}
+
+pub fn new() -> Context {
+  Context(
+    level_text,
+    text_formatter,
+    [],
+    Info,
+    new_metadata(),
+    default_handler(),
+    [],
+  )
+}
+
+@external(erlang, "comet_ffi", "configure")
+@external(javascript, "./logs.mjs", "set_config")
+pub fn configure(ctx: Context) -> Nil
+
+pub fn set_level_text(ctx: Context, func: fn(Level) -> String) -> Context {
+  Context(..ctx, level_text: func)
+}
+
+pub fn set_formatter(ctx: Context, formatter: Formatter) -> Context {
+  Context(..ctx, formatter: formatter)
+}
+
+pub fn level(ctx: Context, level: Level) -> Context {
+  Context(..ctx, min_level: level)
+}
+
+pub fn with_attribute(ctx: Context, attr: Attribute) -> Context {
+  Context(..ctx, metadata: attribute(ctx.metadata, attr))
+}
+
+@target(erlang)
+pub type Handler {
+  Handler(
+    module: Atom,
+    min_level: Level,
+    formatter_module: Atom,
+    filters: List(ErlangFilter),
+    metadata: Metadata,
+  )
+}
+
+@target(erlang)
+fn default_handler() -> Option(Handler) {
+  None
+}
+
+@target(javascript)
+pub type Handler {
+  Handler(
+    name: String,
+    min_level: Level,
+    formatter: Formatter,
+    filters: Filters,
+    metadata: Metadata,
+  )
+}
+
+@target(javascript)
+fn default_handler() {
+  None
+}
+
+@target(erlang)
+pub type HandlerFn =
+  fn(Dict(Atom, Dynamic)) -> Nil
+
+@target(javascript)
+pub type HandlerFn =
+  fn(Entry) -> Nil
+
+@target(javascript)
+pub fn add_handler(ctx: Context, handler: Handler) -> Context {
+  Context(..ctx, handlers: list.append(ctx.handlers, [handler]))
+}
+
+// Metadata ---------------------------------------------------------------------------
+
+pub type Metadata =
+  List(Attribute)
+
+fn new_metadata() -> Metadata {
+  []
+}
+
+pub type Attribute {
+  STR(name: String, value: String)
+  INT(name: String, value: Int)
+  FLOAT(name: String, value: Float)
+  BOOL(name: String, value: Bool)
+}
+
+// pub fn json_formatter(
+//   level: Level,
+//   msg: String,
+//   attributes: List(Attribute),
+// ) -> String {
+//   list.map(
+//     list.concat([
+//       [String("level", get_level_text(level))],
+//       attributes,
+//       [String("msg", msg)],
+//     ]),
+//     attribute_to_json,
+//   )
+//   |> json.object
+//   |> json.to_string
+// }
+
+fn attribute_to_json(attr: Attribute) -> #(String, json.Json) {
+  case attr {
+    STR(key, value) -> #(key, json.string(value))
+    INT(key, value) -> #(key, json.int(value))
+    FLOAT(key, value) -> #(key, json.float(value))
+    BOOL(key, value) -> #(key, json.bool(value))
+  }
+}
+
+fn package_metadata_for_erlang(md: Metadata) -> Dict(Atom, Attribute) {
+  add_atom_attributes_to_dict(md, dict.new())
+}
+
+fn add_atom_attributes_to_dict(
+  md: Metadata,
+  data: Dict(Atom, Attribute),
+) -> Dict(Atom, Attribute) {
+  case md {
+    [] -> data
+    [first, ..rest] ->
+      add_atom_attributes_to_dict(
+        rest,
+        dict.insert(data, key_name(first.name), first),
+      )
+  }
+}
+
+fn attribute_decoder(
+  value: Dynamic,
+) -> Result(Attribute, List(dynamic.DecodeError)) {
+  case dynamic.classify(value) {
+    "STR" -> Ok(unsafe_dynamic_to_attribute(value))
+    "BOOL" -> Ok(unsafe_dynamic_to_attribute(value))
+    "INT" -> Ok(unsafe_dynamic_to_attribute(value))
+    "FLOAT" -> Ok(unsafe_dynamic_to_attribute(value))
+    _ -> Error([])
+  }
+}
+
+fn unsafe_dynamic_to_attribute(value: Dynamic) -> Attribute {
+  dynamic.unsafe_coerce(value)
+}
+
+pub fn attribute(md: Metadata, attribute: Attribute) -> Metadata {
+  list.prepend(md, attribute)
+}
+
+// Filters ---------------------------------------------------------------------------
+// TODO: 
+//    - fix erlang filters..or try to understand them better and reimplement the filtering system 
+//    - implement javascript s
+
 pub type Entry {
   Entry(level: Level, message: String, metadata: Metadata)
 }
 
-@target(javascript)
-@external(javascript, "./logs.mjs", "insert_attribute")
-pub fn attribute(md: Metadata, key: String, value: e) -> Metadata
+type Filter =
+  fn(Entry) -> Option(Entry)
+
+pub type ErlangFilter
 
 @target(erlang)
-pub fn attribute(md: Metadata, key: String, value: e) -> Metadata {
-  dict.insert(md, key_name(key), dynamic.from(value))
+type Filters =
+  List(ErlangFilter)
+
+@target(javascript)
+type Filters =
+  List(Filter)
+
+@target(javascript)
+pub fn add_allow_metadata_filter(
+  ctx: Context,
+  name: String,
+  filter: Filter,
+) -> Context {
+  Context(..ctx, filters: list.append(ctx.filters, [#(name, filter)]))
+}
+
+@external(erlang, "comet_ffi", "allow_metadata_filter")
+fn add_allow_metadata_filter_erlang(keys: List(Atom)) -> ErlangFilter
+
+@external(erlang, "comet_ffi", "deny_metadata_filter")
+fn add_deny_metadata_filter_erlang(keys: List(Atom)) -> ErlangFilter
+
+@target(erlang)
+pub fn add_allow_metadata_filter(ctx: Context, keys: List(String)) -> Context {
+  Context(
+    ..ctx,
+    filters: list.append(ctx.filters, [
+      add_allow_metadata_filter_erlang(list.map(keys, fn(k) { key_name(k) })),
+    ]),
+  )
 }
 
 @target(erlang)
-pub fn format(log: Dict(Atom, Dynamic), config) -> List(String) {
-  let level: Level = extract_level_from_erlang_log(log)
-  let metadata: Metadata = extract_metadata_from_erlang_log(log)
-  let msg: String = extract_msg_from_erlang_log(log)
+pub fn add_allow_metadata_filter_to_handler(
+  handler: Handler,
+  keys: List(String),
+) -> Handler {
+  Handler(
+    ..handler,
+    filters: list.append(handler.filters, [
+      add_allow_metadata_filter_erlang(list.map(keys, fn(k) { key_name(k) })),
+    ]),
+  )
+}
 
-  ["level:", level_text(level), " | ", msg, string.inspect(metadata)]
+@target(erlang)
+pub fn add_deny_metadata_filter(ctx: Context, keys: List(String)) -> Context {
+  Context(
+    ..ctx,
+    filters: list.append(ctx.filters, [
+      add_deny_metadata_filter_erlang(list.map(keys, fn(k) { key_name(k) })),
+    ]),
+  )
+}
+
+@target(erlang)
+pub fn add_deny_metadata_filter_to_handler(
+  handler: Handler,
+  keys: List(String),
+) -> Handler {
+  Handler(
+    ..handler,
+    filters: list.append(handler.filters, [
+      add_deny_metadata_filter_erlang(list.map(keys, fn(k) { key_name(k) })),
+    ]),
+  )
+}
+
+// Formatting ---------------------------------------------------------------------------
+
+@target(erlang)
+type Formatter =
+  fn(Entry) -> List(String)
+
+@target(javascript)
+type Formatter =
+  fn(Entry) -> #(String, List(Dynamic))
+
+@target(erlang)
+pub fn text_formatter(entry: Entry) -> List(String) {
+  let Entry(level, msg, md) = entry
+  ["level: ", level_text(level), " | ", msg, " | ", string.inspect(md)]
+}
+
+@target(erlang)
+pub fn json_formatter(entry: Entry) -> List(String) {
+  todo
+  // let Entry(level, msg, md) = entry
+  // md
+  // |> dict.insert(key_name("level"), level_text(level))
+  // |> dict.insert(key_name("msg"), msg)
+  // let fields = [#("level", json.string(level_text(level)), #("msg", json.string(msg)))]
+  // |> list.append()
+  // json.object()
+}
+
+@target(javascript)
+pub fn text_formatter(entry: Entry) -> #(String, List(Dynamic)) {
+  let Entry(level, msg, md) = entry
+  let msg =
+    ["level:", level_text(level), "|", msg]
+    |> string.join(" ")
+  #(msg, [dynamic.from(md)])
+}
+
+@target(erlang)
+type LogEvent {
+  Dict(Atom, Attribute)
+  String
+}
+
+@target(erlang)
+pub fn format(
+  log: Dict(Atom, Dynamic),
+  config: List(#(Atom, Context)),
+) -> List(String) {
+  let ctx = extract_context_from_config(config)
+  ctx.formatter(extract_entry_from_erlang_log_event(log))
+}
+
+fn extract_context_from_config(config: List(#(Atom, Context))) -> Context {
+  case list.first(config) {
+    Ok(#(_, v)) -> v
+    _ -> new()
+  }
+}
+
+@target(erlang)
+fn extract_entry_from_erlang_log_event(log: Dict(Atom, Dynamic)) -> Entry {
+  let level: Level = extract_level_from_erlang_log(log)
+  let msg: String = extract_msg_from_erlang_log(log)
+  let metadata: Metadata = extract_metadata_from_erlang_log(log)
+  Entry(level, msg, metadata)
 }
 
 @target(erlang)
@@ -92,7 +365,7 @@ fn extract_metadata_from_erlang_log(log: Dict(Atom, Dynamic)) -> Metadata {
   case dict.get(log, key_name("meta")) {
     Ok(value) ->
       case dynamic.dict(atom.from_dynamic, dynamic.dynamic)(value) {
-        Ok(md) -> md
+        Ok(md) -> list.filter_map(dict.values(md), attribute_decoder)
         _ -> new_metadata()
       }
     _ -> new_metadata()
@@ -103,6 +376,19 @@ fn extract_metadata_from_erlang_log(log: Dict(Atom, Dynamic)) -> Metadata {
 fn extract_level_from_erlang_log(log: Dict(Atom, Dynamic)) -> Level {
   case dict.get(log, key_name("level")) {
     Ok(value) -> decode_level(value)
+    _ -> Err
+  }
+}
+
+@target(erlang)
+fn decode_level(value: Dynamic) -> Level {
+  case atom.from_dynamic(value) {
+    Ok(level) -> {
+      case atom.to_string(level) {
+        "debug" -> Debug
+        _ -> Err
+      }
+    }
     _ -> Err
   }
 }
@@ -124,71 +410,18 @@ fn extract_msg_from_erlang_log(log: Dict(Atom, Dynamic)) -> String {
   }
 }
 
-@target(erlang)
-fn decode_level(value: Dynamic) -> Level {
-  case atom.from_dynamic(value) {
-    Ok(level) -> {
-      case atom.to_string(level) {
-        "debug" -> Debug
-        _ -> Err
-      }
-    }
-    _ -> Err
-  }
-}
-
-@external(javascript, "./logs.mjs", "new_metadata")
-fn new_metadata() -> Metadata {
-  dict.new()
-}
-
-@target(javascript)
-pub type Json
-
-@target(javascript)
-type Metadata =
-  Json
-
-@target(erlang)
-type Metadata =
-  Dict(Atom, Dynamic)
-
-type Formatter =
-  fn(Entry) -> String
-
-@target(erlang)
-fn formatter_wrapper(entry: #(Level, String, Metadata)) -> Entry {
-  Entry(level: entry.0, message: entry.1, metadata: entry.2)
-}
-
-fn text_formatter(entry: Entry) -> String {
-  todo
-}
-
-type Output =
-  fn(Entry) -> Nil
-
-type Filter =
-  fn(Entry) -> Bool
-
-@target(erlang)
-type Filters =
-  Dict(Atom, Filter)
-
-@target(javascript)
-type Filters =
-  Dict(String, Filter)
-
-pub fn with_filter(
-  config: Configuration,
-  name: String,
-  filter: Filter,
-) -> Configuration {
-  Configuration(
-    ..config,
-    filters: dict.insert(config.filters, key_name(name), filter),
-  )
-}
+// @target(erlang)
+// fn decode_level(value: Dynamic) -> Level {
+//   case atom.from_dynamic(value) {
+//     Ok(level) -> {
+//       case atom.to_string(level) {
+//         "debug" -> Debug
+//         _ -> Err
+//       }
+//     }
+//     _ -> Err
+//   }
+// }
 
 @target(erlang)
 fn key_name(name: String) -> Atom {
@@ -203,6 +436,8 @@ fn key_name(name: String) -> String {
   name
 }
 
+// Log APIs ---------------------------------------------------------------------------
+
 pub fn log() -> Metadata {
   new_metadata()
 }
@@ -215,9 +450,9 @@ pub fn debug(md: Metadata, msg: String) -> Nil
 @external(javascript, "./logs.mjs", "info")
 pub fn info(md: Metadata, msg: String) -> Nil
 
-@external(erlang, "comet_ffi", "warn")
-@external(javascript, "./logs.mjs", "warn")
-pub fn warn(md: Metadata, msg: String) -> Nil
+@external(erlang, "comet_ffi", "warning")
+@external(javascript, "./logs.mjs", "warning")
+pub fn warning(md: Metadata, msg: String) -> Nil
 
 @external(erlang, "comet_ffi", "error")
 @external(javascript, "./logs.mjs", "error")

--- a/src/comet_ffi.erl
+++ b/src/comet_ffi.erl
@@ -8,11 +8,11 @@ error(Metadata, Message) -> log(error, Message, Metadata).
 log(Level, Message, Metadata) -> logger:log(Level, Message, Metadata).
 
 configure(Config) ->
-    {_Name, _LevelText, _Formatter, Filters, MinLevel} = Config,
+    {_Name, _LevelText, _Formatter,  MinLevel} = Config,
     ok = logger:update_primary_config(#{
         level => MinLevel,
         filter_default => log,
-        filters => Filters,
+        filters => [],
         metadata => #{}
             }),
     ok = logger:update_handler_config(default, #{

--- a/src/comet_ffi.erl
+++ b/src/comet_ffi.erl
@@ -1,5 +1,5 @@
 -module(comet_ffi).
--export([configure/1, debug/2, info/2, warning/2, error/2, allow_metadata_filter/1, deny_metadata_filter/1, add_handler/1]).
+-export([get_attribute_atom/1, configure/1, debug/2, info/2, warning/2, error/2, allow_metadata_filter/1, deny_metadata_filter/1, add_handler/1]).
 
 debug(Metadata, Message) -> log(debug, Message, Metadata).
 info(Metadata, Message) -> log(info, Message, Metadata).
@@ -8,14 +8,13 @@ error(Metadata, Message) -> log(error, Message, Metadata).
 log(Level, Message, Metadata) -> logger:log(Level, Message, Metadata).
 
 configure(Config) ->
-    {_Name, _LevelText, _Formatter, Filters, MinLevel, Metadata, _DefaultHandler,
-        _AdditionalHandlers} = Config,
+    {_Name, _LevelText, _Formatter, Filters, MinLevel, Metadata} = Config,
     erlang:display(Metadata),
     ok = logger:update_primary_config(#{
         level => MinLevel,
         filter_default => log,
         filters => Filters,
-        metadata => Metadata
+        metadata => maps:from_list(Metadata)
     }),
     ok = logger:update_handler_config(default, #{
         formatter => {comet, [#{config => Config}]}
@@ -38,3 +37,7 @@ allow_metadata_filter(Domains) ->
 
 deny_metadata_filter(Domains) ->
     {domain, {fun logger_filters:domain/2, {stop, sub, Domains}}}.
+
+get_attribute_atom(Attribute) ->
+    [First|_] = tuple_to_list(Attribute),
+    First.

--- a/src/comet_ffi.erl
+++ b/src/comet_ffi.erl
@@ -1,0 +1,24 @@
+-module(comet_ffi).
+-export([configure/1, debug/2, info/2,warn/2,error/2]).
+
+debug(Metadata, Message) -> log(debug, Message, Metadata).
+info(Metadata, Message) -> log(info, Message, Metadata).
+warn(Metadata, Message) -> log(warning, Message, Metadata).
+error(Metadata, Message) -> log(error, Message, Metadata).
+log(Level, Message, Metadata) -> logger:log(Level, Message, Metadata).
+
+configure(Config) ->
+    ok = logger:update_primary_config(#{
+        level => debug,
+        filter_default => log,
+        filters => [
+            {domain,{fun logger_filters:domain/2, {stop, sub, [otp,sasl]}}},
+            {domain,{fun logger_filters:domain/2, {stop, sub, [supervisor_report]}}}
+        ],
+        metadata => #{foo => "bar"}
+    }),
+    ok = logger:update_handler_config(default, #{
+        formatter => {comet, [#{config=> Config}]}
+    }),
+    nil.
+

--- a/src/comet_ffi.erl
+++ b/src/comet_ffi.erl
@@ -1,24 +1,40 @@
 -module(comet_ffi).
--export([configure/1, debug/2, info/2,warn/2,error/2]).
+-export([configure/1, debug/2, info/2, warning/2, error/2, allow_metadata_filter/1, deny_metadata_filter/1, add_handler/1]).
 
 debug(Metadata, Message) -> log(debug, Message, Metadata).
 info(Metadata, Message) -> log(info, Message, Metadata).
-warn(Metadata, Message) -> log(warning, Message, Metadata).
+warning(Metadata, Message) -> log(warning, Message, Metadata).
 error(Metadata, Message) -> log(error, Message, Metadata).
 log(Level, Message, Metadata) -> logger:log(Level, Message, Metadata).
 
 configure(Config) ->
+    {_Name, _LevelText, _Formatter, Filters, MinLevel, Metadata, _DefaultHandler,
+        _AdditionalHandlers} = Config,
+    erlang:display(Metadata),
     ok = logger:update_primary_config(#{
-        level => debug,
+        level => MinLevel,
         filter_default => log,
-        filters => [
-            {domain,{fun logger_filters:domain/2, {stop, sub, [otp,sasl]}}},
-            {domain,{fun logger_filters:domain/2, {stop, sub, [supervisor_report]}}}
-        ],
-        metadata => #{foo => "bar"}
+        filters => Filters,
+        metadata => Metadata
     }),
     ok = logger:update_handler_config(default, #{
-        formatter => {comet, [#{config=> Config}]}
+        formatter => {comet, [#{config => Config}]}
     }),
     nil.
 
+add_handler(Handler) ->
+    {Module, MinLevel, Formatter, Filters, Metadata} = Handler,
+    ok = logger:add_handler(Module, #{
+        level => MinLevel,
+        filter_default => log,
+        filters => Filters,
+        formatter => Formatter,
+        metadata => Metadata
+    }),
+    nil.
+
+allow_metadata_filter(Domains) ->
+   {domain, {fun logger_filters:domain/2, {log, sub, Domains}}}.
+
+deny_metadata_filter(Domains) ->
+    {domain, {fun logger_filters:domain/2, {stop, sub, Domains}}}.

--- a/src/comet_ffi.erl
+++ b/src/comet_ffi.erl
@@ -8,14 +8,13 @@ error(Metadata, Message) -> log(error, Message, Metadata).
 log(Level, Message, Metadata) -> logger:log(Level, Message, Metadata).
 
 configure(Config) ->
-    {_Name, _LevelText, _Formatter, Filters, MinLevel, Metadata} = Config,
-    erlang:display(Metadata),
+    {_Name, _LevelText, _Formatter, Filters, MinLevel} = Config,
     ok = logger:update_primary_config(#{
         level => MinLevel,
         filter_default => log,
         filters => Filters,
-        metadata => maps:from_list(Metadata)
-    }),
+        metadata => #{}
+            }),
     ok = logger:update_handler_config(default, #{
         formatter => {comet, [#{config => Config}]}
     }),

--- a/src/logs.mjs
+++ b/src/logs.mjs
@@ -1,0 +1,31 @@
+let config = {}
+
+export function set_config(configuration) {
+  console.debug("set_config")
+  console.info("fizz", configuration)
+}
+
+export function debug(metadata, message) {
+  console.debug(message, metadata)
+}
+
+export function info(metadata, message) {
+  console.info(message, metadata)
+}
+
+export function warn(metadata, message) {
+  console.warn(message, metadata)
+}
+
+export function error(metadata, message) {
+  console.error(message, metadata)
+}
+
+export function new_metadata() {
+  return {} 
+}
+
+export function insert_attribute(metadata, key, value) {
+  metadata[key] = value
+  return metadata
+}

--- a/src/logs.mjs
+++ b/src/logs.mjs
@@ -5,22 +5,17 @@ export function set_config(configuration) {
 }
 
 export function debug(level, metadata, message) {
- console.debug(config.formatter({level, message, metadata}))
+ console.debug(config.formatter(config, {level, message, metadata}))
 }
 
 export function info(level, metadata, message) {
- console.info(config.formatter({level, message, metadata}))
+ console.info(config.formatter(config, {level, message, metadata}))
 }
 
 export function warning(level, metadata, message) {
- console.warn(config.formatter({level, message, metadata}))
+ console.warn(config.formatter(config, {level, message, metadata}))
 }
 
 export function error(level, metadata, message) {
- console.error(config.formatter({level, message, metadata}))
+ console.error(config.formatter(config, {level, message, metadata}))
 }
-
-// export function insert_attribute(metadata, key, value) {
-//   metadata[key] = value
-//   return metadata
-// }

--- a/src/logs.mjs
+++ b/src/logs.mjs
@@ -1,31 +1,26 @@
 let config = {}
 
 export function set_config(configuration) {
-  console.debug("set_config")
-  console.info("fizz", configuration)
+  config = configuration
 }
 
-export function debug(metadata, message) {
-  console.debug(message, metadata)
+export function debug(level, metadata, message) {
+ console.debug(config.formatter({level, message, metadata}))
 }
 
-export function info(metadata, message) {
-  console.info(message, metadata)
+export function info(level, metadata, message) {
+ console.info(config.formatter({level, message, metadata}))
 }
 
-export function warn(metadata, message) {
-  console.warn(message, metadata)
+export function warning(level, metadata, message) {
+ console.warn(config.formatter({level, message, metadata}))
 }
 
-export function error(metadata, message) {
-  console.error(message, metadata)
+export function error(level, metadata, message) {
+ console.error(config.formatter({level, message, metadata}))
 }
 
-export function new_metadata() {
-  return {} 
-}
-
-export function insert_attribute(metadata, key, value) {
-  metadata[key] = value
-  return metadata
-}
+// export function insert_attribute(metadata, key, value) {
+//   metadata[key] = value
+//   return metadata
+// }

--- a/test/comet_test.gleam
+++ b/test/comet_test.gleam
@@ -1,4 +1,4 @@
-import comet.{attribute, debug, error, info, warning}
+import comet.{attribute, attributes, debug, error, info, warning}
 import gleeunit
 
 pub fn main() {
@@ -27,9 +27,7 @@ pub fn metadata_test() {
   |> debug("did this work? hi mom")
 
   log
-  |> attribute(Latency(24.2))
-  |> attribute(StatusCode(200))
-  |> attribute(Success(True))
+  |> attributes([Latency(24.2), StatusCode(200), Success(True)])
   |> info("access log")
 
   log

--- a/test/comet_test.gleam
+++ b/test/comet_test.gleam
@@ -25,11 +25,12 @@ type Attribute {
 pub fn metadata_test() {
   comet.new()
   |> comet.level(comet.Debug)
-  |> comet.with_attribute(STR("service", "comet"))
+  |> comet.with_attribute(Service("comet"))
   |> comet.configure()
 
   comet.log()
-  |> comet.attribute(STR("lyric", "i'm feeling doooooown"))
-  |> comet.attribute(STR("time", birl.to_iso8601(birl.utc_now())))
+  |> comet.attribute(Latency(24.2))
+  |> comet.attribute(StatusCode(200))
+  |> comet.attribute(Success(True))
   |> comet.info("help!")
 }

--- a/test/comet_test.gleam
+++ b/test/comet_test.gleam
@@ -1,15 +1,5 @@
-import birl
-import comet
-import gleam/dict
-import gleam/dynamic
-import gleam/erlang/process.{type Subject}
-import gleam/io
-import gleam/json
-import gleam/list
-import gleam/option.{type Option, None, Some}
-import gleam/otp/actor
+import comet.{attribute, debug, error, info, warning}
 import gleeunit
-import gleeunit/should
 
 pub fn main() {
   gleeunit.main()
@@ -20,17 +10,39 @@ type Attribute {
   Latency(Float)
   StatusCode(Int)
   Success(Bool)
+  Err(String)
 }
 
+// todo: tests were removed since log handlers are not yet implemented.
 pub fn metadata_test() {
   comet.new()
   |> comet.level(comet.Debug)
-  |> comet.with_attribute(Service("comet"))
   |> comet.configure()
 
-  comet.log()
-  |> comet.attribute(Latency(24.2))
-  |> comet.attribute(StatusCode(200))
-  |> comet.attribute(Success(True))
-  |> comet.info("help!")
+  let log =
+    comet.log()
+    |> attribute(Service("comet"))
+
+  log
+  |> debug("did this work? hi mom")
+
+  log
+  |> attribute(Latency(24.2))
+  |> attribute(StatusCode(200))
+  |> attribute(Success(True))
+  |> info("access log")
+
+  log
+  |> attribute(Latency(102.2))
+  |> attribute(StatusCode(400))
+  |> attribute(Err("input not accepted"))
+  |> attribute(Success(False))
+  |> warning("access log")
+
+  log
+  |> attribute(Latency(402.0))
+  |> attribute(StatusCode(500))
+  |> attribute(Err("database connection error"))
+  |> attribute(Success(False))
+  |> error("access log")
 }

--- a/test/comet_test.gleam
+++ b/test/comet_test.gleam
@@ -6,6 +6,7 @@ import gleam/erlang/process.{type Subject}
 import gleam/io
 import gleam/json
 import gleam/list
+import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleeunit
 import gleeunit/should
@@ -14,12 +15,21 @@ pub fn main() {
   gleeunit.main()
 }
 
+type Attribute {
+  Service(String)
+  Latency(Float)
+  StatusCode(Int)
+  Success(Bool)
+}
+
 pub fn metadata_test() {
-  comet.configure(comet.new())
+  comet.new()
+  |> comet.level(comet.Debug)
+  |> comet.with_attribute(STR("service", "comet"))
+  |> comet.configure()
+
   comet.log()
-  |> comet.attribute("lyric", "i'm feeling doooooown")
-  |> comet.attribute("hot dog", ["flip flop"])
-  |> comet.attribute("penny lane", #("fizz", "buzz", 1238))
-  |> comet.attribute("time", birl.to_iso8601(birl.utc_now()))
-  |> comet.debug("help!")
+  |> comet.attribute(STR("lyric", "i'm feeling doooooown"))
+  |> comet.attribute(STR("time", birl.to_iso8601(birl.utc_now())))
+  |> comet.info("help!")
 }

--- a/test/comet_test.gleam
+++ b/test/comet_test.gleam
@@ -1,4 +1,6 @@
+import birl
 import comet
+import gleam/dict
 import gleam/dynamic
 import gleam/erlang/process.{type Subject}
 import gleam/io
@@ -12,134 +14,12 @@ pub fn main() {
   gleeunit.main()
 }
 
-type LogMessage {
-  Entry(String)
-  Retrieve(Subject(List(String)))
-}
-
-fn log_aggregator(
-  msg: LogMessage,
-  logs: List(String),
-) -> actor.Next(LogMessage, List(String)) {
-  case msg {
-    Entry(entry) -> actor.continue(list.append(logs, [entry]))
-    Retrieve(subject) -> {
-      process.send(subject, logs)
-      actor.continue(logs)
-    }
-  }
-}
-
-pub fn log_test() {
-  let assert Ok(output) = actor.start([], log_aggregator)
-  let log =
-    comet.builder()
-    |> comet.output(fn(msg: String, level: comet.Level) -> Nil {
-      comet.write_output(msg, level)
-      process.send(output, Entry(msg))
-      Nil
-    })
-    |> comet.logger
-  log(comet.Trace, "Trace", [comet.String("region", "us-west4")])
-  log(comet.Debug, "Debug", [comet.Bool("gleam_rocks", True)])
-  log(comet.Info, "Info", [comet.Int("num_pets", 18)])
-  log(comet.Warn, "Warn", [comet.Float("chance_of_success", 33.3333333)])
-  log(comet.Error, "Error", [
-    comet.Fn(fn() -> comet.Attribute { comet.String("lang", "gleam") }),
-  ])
-
-  should.equal(process.call(output, Retrieve, 10), [
-    "{\"level\":\"trace\",\"region\":\"us-west4\",\"msg\":\"Trace\"}",
-    "{\"level\":\"debug\",\"gleam_rocks\":true,\"msg\":\"Debug\"}",
-    "{\"level\":\"info\",\"num_pets\":18,\"msg\":\"Info\"}",
-    "{\"level\":\"warn\",\"chance_of_success\":33.3333333,\"msg\":\"Warn\"}",
-    "{\"level\":\"error\",\"lang\":\"gleam\",\"msg\":\"Error\"}",
-  ])
-}
-
-pub fn log_level_test() {
-  let assert Ok(output) = actor.start([], log_aggregator)
-  let log =
-    comet.builder()
-    |> comet.output(fn(msg: String, level: comet.Level) -> Nil {
-      comet.write_output(msg, level)
-      process.send(output, Entry(msg))
-      Nil
-    })
-    |> comet.log_level(comet.Warn)
-    |> comet.logger
-  log(comet.Trace, "Trace", [comet.String("region", "us-west4")])
-  log(comet.Debug, "Debug", [comet.Bool("gleam_rocks", True)])
-  log(comet.Info, "Info", [comet.Int("num_pets", 18)])
-  log(comet.Warn, "Warn", [comet.Float("chance_of_success", 33.3333333)])
-  log(comet.Error, "Error", [
-    comet.Fn(fn() -> comet.Attribute { comet.String("lang", "gleam") }),
-  ])
-
-  should.equal(process.call(output, Retrieve, 10), [
-    "{\"level\":\"warn\",\"chance_of_success\":33.3333333,\"msg\":\"Warn\"}",
-    "{\"level\":\"error\",\"lang\":\"gleam\",\"msg\":\"Error\"}",
-  ])
-}
-
-type LogEntry {
-  LogEntry(level: String, msg: String, timestamp: String)
-}
-
-pub fn timestamp_log_test() {
-  let assert Ok(output) = actor.start([], log_aggregator)
-  let log =
-    comet.builder()
-    |> comet.output(fn(msg: String, _: comet.Level) -> Nil {
-      io.debug(msg)
-      process.send(output, Entry(msg))
-      Nil
-    })
-    |> comet.timestamp
-    |> comet.logger
-  log(comet.Trace, "Trace", [])
-
-  let logs = process.call(output, Retrieve, 10)
-
-  let log_decoder =
-    dynamic.decode3(
-      LogEntry,
-      dynamic.field("level", dynamic.string),
-      dynamic.field("msg", dynamic.string),
-      dynamic.field("timestamp", dynamic.string),
-    )
-  case logs {
-    [raw] -> {
-      let assert Ok(entry) = json.decode(raw, log_decoder)
-      should.not_equal(entry.timestamp, "")
-      should.equal(entry, LogEntry("trace", "Trace", entry.timestamp))
-    }
-    _ -> should.fail()
-  }
-}
-
-pub fn level_log_test() {
-  let assert Ok(output) = actor.start([], log_aggregator)
-  let assert comet.LevelLoggerSet(trace, debug, info, warn, err) =
-    comet.builder()
-    |> comet.output(fn(msg: String, level: comet.Level) -> Nil {
-      process.send(output, Entry(msg))
-      Nil
-    })
-    |> comet.attributes([comet.String("service", "comet")])
-    |> comet.logger
-    |> comet.levels
-  trace("Trace", [])
-  debug("Debug", [])
-  info("Info", [])
-  warn("Warn", [])
-  err("Error", [])
-
-  should.equal(process.call(output, Retrieve, 10), [
-    "{\"level\":\"trace\",\"service\":\"comet\",\"msg\":\"Trace\"}",
-    "{\"level\":\"debug\",\"service\":\"comet\",\"msg\":\"Debug\"}",
-    "{\"level\":\"info\",\"service\":\"comet\",\"msg\":\"Info\"}",
-    "{\"level\":\"warn\",\"service\":\"comet\",\"msg\":\"Warn\"}",
-    "{\"level\":\"error\",\"service\":\"comet\",\"msg\":\"Error\"}",
-  ])
+pub fn metadata_test() {
+  comet.configure(comet.new())
+  comet.log()
+  |> comet.attribute("lyric", "i'm feeling doooooown")
+  |> comet.attribute("hot dog", ["flip flop"])
+  |> comet.attribute("penny lane", #("fizz", "buzz", 1238))
+  |> comet.attribute("time", birl.to_iso8601(birl.utc_now()))
+  |> comet.debug("help!")
 }

--- a/test/comet_test.gleam
+++ b/test/comet_test.gleam
@@ -16,7 +16,7 @@ type Attribute {
 // todo: tests were removed since log handlers are not yet implemented.
 pub fn metadata_test() {
   comet.new()
-  |> comet.level(comet.Debug)
+  |> comet.with_level(comet.Debug)
   |> comet.configure()
 
   let log =
@@ -45,4 +45,59 @@ pub fn metadata_test() {
   |> attribute(Err("database connection error"))
   |> attribute(Success(False))
   |> error("access log")
+}
+
+fn levels(level: comet.Level) -> String {
+  case level {
+    comet.Debug -> "DEBG"
+    comet.Info -> "INFO"
+    comet.Warning -> "WARN"
+    comet.Err -> "ERR"
+    comet.Panic -> "PANIC"
+  }
+}
+
+pub fn level_text_test() {
+  comet.new()
+  |> comet.with_level(comet.Debug)
+  |> comet.with_level_text(levels)
+  |> comet.configure
+
+  let log = comet.log()
+
+  log
+  |> debug("should be DEBG")
+
+  log
+  |> info("should be INFO")
+
+  log
+  |> warning("should be WARN")
+
+  log
+  |> error("should be ERR")
+}
+
+@target(erlang)
+fn formatter(_, _) {
+  ["JUST THIS"]
+}
+
+@target(javascript)
+fn formatter(_, _) {
+  "JUST THIS"
+}
+
+pub fn formatter_test() {
+  comet.new()
+  |> comet.with_level(comet.Debug)
+  |> comet.with_formatter(formatter)
+  |> comet.configure()
+
+  let log =
+    comet.log()
+    |> attribute(Service("comet"))
+
+  log
+  |> info("something")
 }


### PR DESCRIPTION
Significantly refactor the code to take advantage of the erlang logger and still work work fairly closely to and maintain a similar API to the javascript target. This PR is incomplete. There are many features that need to be re-implemented and re-planned, particularly log filters and handlers.

Another significant change is using generic types and the gleam type system for attributes. This should allow for greater flexibility in registered formatters or format wrappers down the road. However, it's doing some trickery to extract Atoms from the underling erlang data structure for records.

#4 