### PR TITLE
feat: Formatter improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ pub fn main() {
 
 outputs the log
 ```
-level: debug | [Service("comet")] | did this work? hi mom
-level: info | [Success(True), StatusCode(200), Latency(24.2), Service("comet")] | access log
-level: warn | [Success(False), Err("input not accepted"), StatusCode(400), Latency(102.2), Service("comet")] | access log
-level: error | [Success(False), Err("database connection error"), StatusCode(500), Latency(402.0), Service("comet")] | access log
+level=debug time=2024-04-28T06:58:37.879Z attributes=[Service("comet")] msg=did this work? hi mom
+level=info time=2024-04-28T06:58:37.883Z attributes=[Service("comet"), Latency(24.2), StatusCode(200), Success(True)] msg=access log
+level=warn time=2024-04-28T06:58:37.883Z attributes=[Success(False), AnError("input not accepted"), StatusCode(400), Latency(102.2), Service("comet")] msg=access log
+level=error time=2024-04-28T06:58:37.884Z attributes=[Success(False), AnError("database connection error"), StatusCode(500), Latency(402.1), Service("comet")] msg=access log
 ```
 
 ## JSON Formatted Logs
@@ -101,7 +101,7 @@ fn main() {
 
 will output the logs:
 ```json
-"{"msg":"a thing","level":"info","service":"comet","success":true}"
+{"msg":"Halley's Comet returns in 2061","time":"2024-04-28T07:04:01.600Z","level":"info","service":"comet","success":true}
 ```
 Further documentation can be found at <https://hexdocs.pm/comet>.
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -10,6 +10,8 @@ gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 gleam_erlang = ">= 0.25.0 and < 1.0.0"
 gleam_javascript = ">= 0.8.0 and < 1.0.0"
 gleam_json = ">= 1.0.1 and < 2.0.0"
+birl = ">= 1.6.1 and < 2.0.0"
+gleam_community_ansi = ">= 1.4.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,19 +2,25 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "birl", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "ranger"], otp_app = "birl", source = "hex", outer_checksum = "976CFF85D34D50F7775896615A71745FBE0C325E50399787088F941B539A0497" },
+  { name = "gleam_community_ansi", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "FE79E08BF97009729259B6357EC058315B6FBB916FAD1C2FF9355115FEB0D3A4" },
+  { name = "gleam_community_colour", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "795964217EBEDB3DA656F5EB8F67D7AD22872EB95182042D3E7AFEF32D3FD2FE" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
   { name = "gleam_javascript", version = "0.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "14D5B7E1A70681E0776BF0A0357F575B822167960C844D3D3FA114D3A75F05A8" },
   { name = "gleam_json", version = "1.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "thoas"], otp_app = "gleam_json", source = "hex", outer_checksum = "9063D14D25406326C0255BDA0021541E797D8A7A12573D849462CAFED459F6EB" },
   { name = "gleam_otp", version = "0.10.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "0B04FE915ACECE539B317F9652CAADBBC0F000184D586AAAF2D94C100945D72B" },
   { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
   { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "ranger", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "ranger", source = "hex", outer_checksum = "1566C272B1D141B3BBA38B25CB761EF56E312E79EC0E2DFD4D3C19FB0CC1F98C" },
   { name = "thoas", version = "1.2.0", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "540C8CB7D9257F2AD0A14145DC23560F91ACDCA995F0CCBA779EB33AF5D859D1" },
 ]
 
 [requirements]
+birl = { version = ">= 1.6.1 and < 2.0.0" }
+gleam_community_ansi = { version = ">= 1.4.0 and < 2.0.0"}
 gleam_erlang = { version = ">= 0.25.0 and < 1.0.0" }
 gleam_javascript = { version = ">= 0.8.0 and < 1.0.0" }
-gleam_json = { version = ">= 1.0.1 and < 2.0.0"}
+gleam_json = { version = ">= 1.0.1 and < 2.0.0" }
 gleam_otp = { version = ">= 0.10.0 and < 1.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/comet_handler.gleam
+++ b/src/comet_handler.gleam
@@ -10,6 +10,8 @@ import gleam/option.{None, Some}
 import gleam/result
 import level.{type Level, Debug, Error as Err, Info, Warning}
 
+const comet_metadata_stash_key = "comet metadata stash key"
+
 @target(erlang)
 pub fn atom(name: String) -> Atom {
   case atom_from_string(name) {
@@ -85,7 +87,7 @@ fn extract_metadata_from_erlang_log(log: Dict(Atom, Dynamic)) -> List(t) {
     Ok(value) ->
       case dynamic.dict(atom_from_dynamic, dynamic.dynamic)(value) {
         Ok(md) ->
-          case dict.get(md, atom(comet.comet_metadata_stash_key)) {
+          case dict.get(md, atom(comet_metadata_stash_key)) {
             Ok(data) ->
               case dynamic.unsafe_coerce(data) {
                 comet.CometAttributeList(data) -> data

--- a/src/level.gleam
+++ b/src/level.gleam
@@ -1,4 +1,5 @@
-// Level ---------------------------------------------------------------------------
+import gleam_community/ansi
+
 pub fn level_priority(level: Level) -> Int {
   case level {
     Debug -> 1
@@ -21,5 +22,14 @@ pub fn level_text(level: Level) -> String {
     Info -> "info"
     Warning -> "warn"
     Error -> "error"
+  }
+}
+
+pub fn level_text_ansi(level: Level) -> String {
+  case level {
+    Debug -> ansi.green("debug")
+    Info -> ansi.blue("info")
+    Warning -> ansi.yellow("warn")
+    Error -> ansi.red("error")
   }
 }


### PR DESCRIPTION
* Improve the Text Formatter to use a cleaner format
* Add Ansi Colors to the text formatter
* Add `json_formatter` support for encoding logs as json
* Add a setting for including timestamps in logs. It is on by default.

closes #14 and closes #6