### PR TITLE
fix: javascript console logging improved with text colorizer function

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ pub fn main() {
   // intitialize the underlying logger settings
   comet.new()
   |> comet.level(Debug)
+  |> comet.with_color_fn(comet.color_plain)
   |> comet.configure
 
   let log = comet.log()


### PR DESCRIPTION
Console logs in the browser using the text formatter were unreadable due to all of the Ansi color codes. Allows for the text formatter to be overridden using the `with_color_fn(ctx, color_plain)`.

#21 